### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/bin.js
+++ b/bin.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const fs = require('fs')
-const convert = require('./')
+import fs from 'node:fs'
+import convert from './index.js'
 
 if (process.argv.includes('--help')) {
   console.error('Usage: gitignore-to-dockerignore')

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,1 @@
-declare function gitignoreToDockerignore (input: string): string
-export = gitignoreToDockerignore
+export default function gitignoreToDockerignore (input: string): string

--- a/index.js
+++ b/index.js
@@ -9,6 +9,6 @@ function transformLine (line) {
   return '**/' + line
 }
 
-module.exports = function gitignoreToDockerignore (input) {
+export default function gitignoreToDockerignore (input) {
   return '.git/\n' + input.split(/\r?\n/g).map(transformLine).join('\n')
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "license": "MIT",
   "repository": "LinusU/gitignore-to-dockerignore",
+  "type": "module",
+  "exports": "./index.js",
   "bin": "bin.js",
   "scripts": {
     "test": "standard && node test"
@@ -16,6 +18,6 @@
     "ignore"
   ],
   "devDependencies": {
-    "standard": "^11.0.1"
+    "standard": "^16.0.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ npm install --save gitignore-to-dockerignore
 ### API
 
 ```js
-const gitignoreToDockerignore = require('gitignore-to-dockerignore')
+import gitignoreToDockerignore from 'gitignore-to-dockerignore'
 
 const input = `
 /node_modules/

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-const convert = require('./')
-const assert = require('assert')
+import assert from 'node:assert'
+import convert from './index.js'
 
 function test (input, expected) {
   assert.strictEqual(convert(input.trim()), expected.trim())


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`