### PR TITLE
💥 Read .gitignore files from subdirectories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        node: [12.20.0, 14.13.1, 16.0.0]
+        node: [18.12.0, 20.9.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/bin.js
+++ b/bin.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs'
-import convert from './index.js'
+import generateDockerignore from './index.js'
 
 if (process.argv.includes('--help')) {
   console.error('Usage: gitignore-to-dockerignore')
 } else {
-  const input = fs.readFileSync('.gitignore').toString()
-  fs.writeFileSync('.dockerignore', convert(input))
+  fs.writeFileSync('.dockerignore', await generateDockerignore(process.cwd()))
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,2 @@
-export default function gitignoreToDockerignore (input: string): string
+export function convertToDockerignore (input: string): string
+export default async function generateDockerignore (directory: string): Promise<string>

--- a/index.js
+++ b/index.js
@@ -1,3 +1,11 @@
+import walk from 'ignore-walk'
+
+import { basename, dirname, join } from 'node:path'
+import { promisify } from 'node:util'
+import { readFile } from 'node:fs/promises'
+
+const walkAsync = promisify(walk)
+
 function transformLine (line) {
   if (line.trim() === '') return ''
   if (line.startsWith('#')) return line
@@ -9,6 +17,39 @@ function transformLine (line) {
   return '**/' + line
 }
 
-export default function gitignoreToDockerignore (input) {
+export function convertToDockerignore (input) {
   return '.git/\n' + input.split(/\r?\n/g).map(transformLine).join('\n')
+}
+
+export default async function generateDockerignore (directory) {
+  const allFiles = await walkAsync({ path: directory, ignoreFiles: ['.gitignore'] })
+  const ignoreFiles = allFiles.filter(file => basename(file) === '.gitignore')
+
+  let result = '.git/\n'
+
+  for (const file of ignoreFiles) {
+    const lines = (await readFile(join(directory, file), 'utf8')).split(/\r?\n/g)
+
+    // Top-most file
+    if (file === '.gitignore') {
+      result += lines.map(transformLine).join('\n') + '\n'
+      continue
+    }
+
+    result += '# From ' + file + '\n'
+
+    for (const line of lines) {
+      const out = transformLine(line)
+
+      if (out === '' || out.startsWith('#')) {
+        result += out + '\n'
+      } else if (out.startsWith('!')) {
+        result += '!' + dirname(file) + '/' + out.slice(1) + '\n'
+      } else {
+        result += dirname(file) + '/' + out + '\n'
+      }
+    }
+  }
+
+  return result
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "exports": "./index.js",
   "bin": "bin.js",
   "scripts": {
-    "test": "standard && node test"
+    "test": "standard && node test-single && node test-recursive"
   },
   "keywords": [
     "convert",
@@ -17,7 +17,14 @@
     "gitignore",
     "ignore"
   ],
+  "dependencies": {
+    "ignore-walk": "^6.0.4"
+  },
   "devDependencies": {
-    "standard": "^16.0.3"
+    "fs-temp": "^2.0.1",
+    "standard": "^17.1.0"
+  },
+  "engines": {
+    "node": "^18.12.0 || >= 20.9.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,8 @@
 # Gitignore → Dockerignore
 
-Generate an equivalent `.dockerignore` file from an existing `.gitignore` file.
+Generate an equivalent `.dockerignore` file from existing `.gitignore` files.
+
+New in 3.0, handles multiple `.gitignore` files in a directory and its subdirectories, just like Git does.
 
 ## Installation
 
@@ -12,15 +14,31 @@ npm install --save gitignore-to-dockerignore
 
 ### API
 
+#### Directory input
+
 ```js
-import gitignoreToDockerignore from 'gitignore-to-dockerignore'
+import generateDockerignore from 'gitignore-to-dockerignore'
+
+console.log(await generateDockerignore(process.cwd()))
+// .git/
+// node_modules/
+// **/*.log
+//
+// # From tests/.gitignore
+// tests/**/*.log
+```
+
+#### String input
+
+```js
+import { convertToDockerignore } from 'gitignore-to-dockerignore'
 
 const input = `
 /node_modules/
 *.log
 `
 
-console.log(gitignoreToDockerignore(input))
+console.log(convertToDockerignore(input))
 // .git/
 // node_modules/
 // **/*.log
@@ -29,6 +47,6 @@ console.log(gitignoreToDockerignore(input))
 ### CLI
 
 ```sh
-# Write a .dockerignore file from .gitignore
+# Write a single .dockerignore file from .gitignore files in the current directory and subdirectories
 gitignore-to-dockerignore
 ```

--- a/test-recursive.js
+++ b/test-recursive.js
@@ -1,0 +1,57 @@
+import assert from 'node:assert'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import temp from 'fs-temp/promises'
+
+import generateDockerignore from './index.js'
+
+const root = await temp.mkdir()
+
+await fs.writeFile(path.join(root, '.gitignore'), '/a/\n/hello.txt\n')
+await fs.writeFile(path.join(root, 'hello.txt'), 'hello')
+
+await fs.mkdir(path.join(root, 'a'))
+await fs.writeFile(path.join(root, 'a/.gitignore'), '/do-not-include.txt\n')
+await fs.writeFile(path.join(root, 'a/do-not-include.txt'), 'hello')
+
+await fs.mkdir(path.join(root, 'b'))
+await fs.writeFile(path.join(root, 'b/.gitignore'), '/ignore-me.txt\n*.mp4\n')
+await fs.writeFile(path.join(root, 'b/ignore-me.txt'), 'hello')
+
+await fs.mkdir(path.join(root, 'c'))
+await fs.writeFile(path.join(root, 'c/.gitignore'), `## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/`)
+
+const actual = await generateDockerignore(root)
+const expected = `
+.git/
+a/
+hello.txt
+
+# From b/.gitignore
+b/ignore-me.txt
+b/**/*.mp4
+
+# From c/.gitignore
+## Various settings
+c/**/*.pbxuser
+!c/**/default.pbxuser
+c/**/*.mode1v3
+!c/**/default.mode1v3
+c/**/*.mode2v3
+!c/**/default.mode2v3
+c/**/*.perspectivev3
+!c/**/default.perspectivev3
+c/**/xcuserdata/
+`
+
+assert.strictEqual(actual.trim(), expected.trim())

--- a/test-single.js
+++ b/test-single.js
@@ -1,8 +1,9 @@
 import assert from 'node:assert'
-import convert from './index.js'
+
+import { convertToDockerignore } from './index.js'
 
 function test (input, expected) {
-  assert.strictEqual(convert(input.trim()), expected.trim())
+  assert.strictEqual(convertToDockerignore(input.trim()), expected.trim())
 }
 
 /* Node.js */


### PR DESCRIPTION
Migration Guide:

This release changes the default API to deal with entire directories instead of a string input, in order to match how Git behaves.

Support for Node.js versions before 18.12.0 is also being dropped.